### PR TITLE
Clean up gatherlogs.automate2.elasticsearch_primary_shard_unavailable…

### DIFF
--- a/profiles/automate2/controls/elasticsearch.rb
+++ b/profiles/automate2/controls/elasticsearch.rb
@@ -85,13 +85,13 @@ Elasticsearch is reporting that there are primary shards that are unavailable.
 
 To attempt a retry for the shards, issue the following
 
-    curl -XPOST 'localhost:10141/_cluster/reroute?retry_failed&pretty'
+    curl -XPOST 'localhost:10144/_cluster/reroute?retry_failed&pretty'
 
 If that gives an error saying the shard is already assigned, then you will need to issue a flush to clear
 the sync ID per each associated index that you received the 'already assigned' error for, and then retry
 the above reroute command
 
-    curl -XPOST 'localhost:10141/INDEX_NAME/_flush?force=true&pretty'
+    curl -XPOST 'localhost:10144/INDEX_NAME/_flush?force=true&pretty'
   "
 
   tag summary: primary_shard.summary
@@ -118,7 +118,7 @@ control 'gatherlogs.automate2.elasticsearch_read_only_indicies' do
 
   Once the disk space issues are resolved, you can remove the read-only flag by
   running the following command from the Automate server:
-    curl -k -XPUT -H \"Content-Type: application/json\" http://localhost:10141/_all/_settings -d '{\"index.blocks.read_only_allow_delete\": null}'
+    curl -k -XPUT -H \"Content-Type: application/json\" http://localhost:10144/_all/_settings -d '{\"index.blocks.read_only_allow_delete\": null}'
   "
 
   tag summary: read_only.summary

--- a/profiles/automate2/controls/elasticsearch.rb
+++ b/profiles/automate2/controls/elasticsearch.rb
@@ -79,22 +79,19 @@ end
 # primary shard is not active
 primary_shard = log_analysis('journalctl_chef-automate.txt', 'primary shard is not active', a2service: 'automate-elasticsearch')
 control 'gatherlogs.automate2.elasticsearch_primary_shard_unavailable' do
-  title 'Check to see if ElasticSearch is reporting issues with primary shards'
+  title 'Check to see if Elasticsearch is reporting issues with primary shards'
   desc "
-ElasticSearch is reporting that there are primary shards that are unavailable.
+Elasticsearch is reporting that there are primary shards that are unavailable.
 
-To find which shards are unavailable you can run
+To attempt a retry for the shards, issue the following
 
-    curl -XGET localhost:10141/_cat/shards?h=index,shard,prirep,state,unassigned.reason| grep UNASSIGNED
+    curl -XPOST 'localhost:10141/_cluster/reroute?retry_failed&pretty'
 
-To attempt a retry for the shards run
+If that gives an error saying the shard is already assigned, then you will need to issue a flush to clear
+the sync ID per each associated index that you received the 'already assigned' error for, and then retry
+the above reroute command
 
-    curl -XPOST localhost:10141/_cluster/reroute?retry_failed
-
-If that gives an error saying the shard is already assigned then you will need to issue a flush to clear
-the sync id and then retry the above reroute command
-
-    curl -XPOST localhost:10141/stats_new/_flush?force=true
+    curl -XPOST 'localhost:10141/INDEX_NAME/_flush?force=true&pretty'
   "
 
   tag summary: primary_shard.summary


### PR DESCRIPTION
… control

* ES is stylized  as Elasticsearch 😅 

* I don't know that the output of `curl -XGET localhost:10141/_cat/shards?h=index,shard,prirep,state,unassigned.reason| grep UNASSIGNED` is all that helpful given that even in healthy A2, plenty of healthy index shards look like this:

```
comp-3-profiles             2 r UNASSIGNED CLUSTER_RECOVERED
```

Is there a different token we can `grep` for?

* Always ask for pretty-print

* Finally, it looks like we copypasta'd straight from https://discuss.elastic.co/t/allocate-stale-primary-primary-is-already-assigned/142995 for the flush instructions; `stats_new` needs to be the relevant index name for each shard that gave the 'already assigned' error. I think 🤷‍♂