### PR TITLE
Add impact filter

### DIFF
--- a/lib/gatherlogs/cli.rb
+++ b/lib/gatherlogs/cli.rb
@@ -18,6 +18,8 @@ module Gatherlogs
     attr_accessor :current_log_path
     attr_writer :profiles
 
+    ALLOWED_IMPACTS = %w{ low medium high critical }.freeze
+
     option ['-p', '--path'], 'PATH',
            'Path to the gatherlogs directory or a compressed bundle',
            default: '.', attribute_name: :log_path
@@ -32,6 +34,10 @@ module Gatherlogs
     option ['-v', '--verbose'], :flag, 'Show inspec test output'
     option ['-a', '--all'], :flag,
            'Show all tests, default is to only show failed tests'
+    option ['-i', '--impact'], 'IMPACT', 'Only show tests that are higher than the given IMPACT value (0-1)', attribute_name: :min_impact do |i|
+      i.to_f
+    end
+
     option ['-q', '--quiet'], :flag, 'Only show the report output'
     option ['-m', '--monochrome'], :flag, "Don't use terminal colors for output"
     option ['--version'], :flag, 'Show current version'
@@ -54,13 +60,13 @@ module Gatherlogs
     def reporter
       @reporter ||= Gatherlogs::Reporter.new(
         show_all_controls: all?,
-        show_all_tests: verbose?
+        show_all_tests: verbose?,
+        min_impact: min_impact
       )
     end
 
     def execute
       parse_args
-
       return show_versions if version?
       return show_profiles if list_profiles?
 

--- a/lib/gatherlogs/cli.rb
+++ b/lib/gatherlogs/cli.rb
@@ -32,9 +32,9 @@ module Gatherlogs
     option ['-v', '--verbose'], :flag, 'Show inspec test output'
     option ['-a', '--all'], :flag,
            'Show all tests, default is to only show failed tests'
-    option ['-i', '--impact'], 'IMPACT', 'Only show tests that are higher than the given IMPACT value (0-1)', attribute_name: :min_impact do |i|
-      i.to_f
-    end
+    option ['-i', '--impact'], 'IMPACT',
+           'Only show tests that are higher than the given IMPACT value (0-1)',
+           attribute_name: :min_impact
 
     option ['-q', '--quiet'], :flag, 'Only show the report output'
     option ['-m', '--monochrome'], :flag, "Don't use terminal colors for output"

--- a/lib/gatherlogs/cli.rb
+++ b/lib/gatherlogs/cli.rb
@@ -18,8 +18,6 @@ module Gatherlogs
     attr_accessor :current_log_path
     attr_writer :profiles
 
-    ALLOWED_IMPACTS = %w{ low medium high critical }.freeze
-
     option ['-p', '--path'], 'PATH',
            'Path to the gatherlogs directory or a compressed bundle',
            default: '.', attribute_name: :log_path

--- a/lib/gatherlogs/control_report.rb
+++ b/lib/gatherlogs/control_report.rb
@@ -55,7 +55,7 @@ module Gatherlogs
       @verbose = tags.include?('verbose') ? tags['verbose'] : false
     end
 
-    def control_marked_as_verbose?
+    def verbose_control?
       @verbose
     end
 
@@ -184,11 +184,13 @@ module Gatherlogs
     end
 
     def show_result?(result)
-      show_all_tests? || source_error?(result) || (control_marked_as_verbose? && result['status'] == 'failed')
+      show_all_tests? || source_error?(result) ||
+        (verbose_control? && result['status'] == 'failed')
     end
 
     def format_result(result)
       return unless show_result?(result)
+
       subsection(format_result_message(result))
     end
   end

--- a/lib/gatherlogs/reporter.rb
+++ b/lib/gatherlogs/reporter.rb
@@ -6,8 +6,6 @@ module Gatherlogs
   class Reporter
     include Gatherlogs::Output
 
-    attr_reader :show_all_controls, :show_all_tests
-
     def initialize(args)
       debug args.inspect
       @options = args
@@ -30,7 +28,7 @@ module Gatherlogs
         profile['controls'],
         @options
       )
-      
+
       {
         system_info: control_report.system_info,
         report: control_report.report

--- a/lib/gatherlogs/reporter.rb
+++ b/lib/gatherlogs/reporter.rb
@@ -9,17 +9,28 @@ module Gatherlogs
     attr_reader :show_all_controls, :show_all_tests
 
     def initialize(args)
-      @show_all_controls = args[:show_all_controls]
-      @show_all_tests = args[:show_all_tests]
+      debug args.inspect
+      @options = args
+    end
+
+    def min_impact
+      @options[:min_impact].to_f || 0.0
+    end
+
+    def show_all_tests
+      @options[:show_all_tests] || false
+    end
+
+    def show_all_controls
+      @options[:show_all_controls] || false
     end
 
     def process_profile(profile)
       control_report = Gatherlogs::ControlReport.new(
         profile['controls'],
-        show_all_controls,
-        show_all_tests
+        @options
       )
-
+      
       {
         system_info: control_report.system_info,
         report: control_report.report

--- a/profiles/automate/controls/issues.rb
+++ b/profiles/automate/controls/issues.rb
@@ -53,8 +53,6 @@ control 'gatherlogs.automate.broken-reaper-cron-file-1.8.3' do
   Please upgrade to a newer version of Automate to ensure reaper run correctly.
   "
 
-  impact 1.0
-
   describe automate do
     its('version') { should_not cmp == '1.8.3' }
   end

--- a/profiles/automate/inspec.yml
+++ b/profiles/automate/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: InSpec profile for automate generated gather-logs
-version: 0.3.5
+version: 0.3.6
 
 depends:
   - name: common

--- a/profiles/automate2/controls/basic.rb
+++ b/profiles/automate2/controls/basic.rb
@@ -33,6 +33,8 @@ services that might be failed, have a short run time or failing their health
 checks.
 "
 
+  impact 'critical'
+
   tag verbose: true
 
   describe services do
@@ -56,6 +58,8 @@ control 'gatherlogs.automate2.critical_disk_usage' do
     There are several key directories that we need to make sure have enough
     free space for automate to operate succesfully
   "
+
+  impact 'critical'
   tag verbose: true
 
   %w[/ /hab /var /var/log].each do |mount|
@@ -113,7 +117,6 @@ end
 
 failed_preflight_checks = log_analysis('chef-automate_preflight-check.txt', 'FAIL', case_sensitive: true)
 control 'gatherlogs.automate2.failed_preflight_checks' do
-  impact 1.0
   title 'Check automate preflight output for any failed tests'
   desc "
 Automate preflight checks are reporting issues failures, the failure for 'automate already deployed'
@@ -133,7 +136,6 @@ end
 
 notification_error = log_analysis('journalctl_chef-automate.txt', 'Notifications.WebhookSender.Impl \[error\] .* failed to post', a2service: 'notifications-service.default')
 control 'gatherlogs.automate2.notifications-failed-to-send' do
-  impact 1.0
   title 'Check to see if the notifications services is reporting errors sending messages'
   desc 'The notification service is encountering an error when trying to set a message to the webhook endpoint'
 

--- a/profiles/automate2/controls/elasticsearch.rb
+++ b/profiles/automate2/controls/elasticsearch.rb
@@ -1,5 +1,6 @@
 control 'gatherlogs.automate2.elasticsearch_1gb_heap_size' do
   title 'Check that ElasticSearch is not configured with the default 1GB heap'
+  impact 'critical'
 
   desc "
 ElasticSearch has been configured to use the default 1GB heap size and needs to

--- a/profiles/automate2/controls/issues.rb
+++ b/profiles/automate2/controls/issues.rb
@@ -2,7 +2,7 @@
 
 upgrade_failed = log_analysis('journalctl_chef-automate.txt', 'level=error msg="Phase failed" error="hab-sup upgrade pending" phase="supervisor upgrade"', a2service: 'service.default')
 control 'gatherlogs.automate2.upgrade_failed' do
-  impact 1.0
+  impact 'critical'
   title 'Check to see if Automate is reporting a failure during the hab sup upgrade process'
   desc "
 It appears that there was a failure during the upgrade process for Automate, please
@@ -18,17 +18,16 @@ end
 
 ldap_group_too_large = log_analysis('journalctl_chef-automate.txt', 'upstream sent too big header while reading response header from upstream.*dex/auth/ldap', a2service: 'automate-load-balancer.default')
 control 'gatherlogs.automate2.auth_upstream_header_too_big' do
-  impact 1.0
+  impact 'medium'
   title 'Check to see if Automate is reporting a failure getting data from an upstream LDAP source'
   desc "
 Automate is reporting errors fetching data from an upstream LDAP source. This commonly
 occurs when LDAP returns too many groups or referencing LDAP groups by distinguished names (DN).
 
-See this link to on how to resolve this issue:
-
-https://automate.chef.io/docs/ldap/#other-common-issues
+To resolve this you will need to add a `group_query_filter` to your Automate configs to
+filter which groups Automate should use
   "
-
+  tag kb: 'https://automate.chef.io/docs/ldap/#other-common-issues'
   tag summary: ldap_group_too_large.summary
 
   describe ldap_group_too_large do
@@ -38,7 +37,7 @@ end
 
 es_gc = log_analysis('journalctl_chef-automate.txt', '\[o.e.m.j.JvmGcMonitorService\] .* \[gc\]', a2service: 'automate-elasticsearch.default')
 control 'gatherlogs.automate2.elasticsearch-high-gc-counts' do
-  impact 1.0
+  impact 'high'
   title 'Check to see if the ElasticSearch is reporting large number of GC events'
   desc "
 The ElasticSearch service is reporting a large number of GC events, this is usually
@@ -55,7 +54,7 @@ end
 
 es_oom = log_analysis('journalctl_chef-automate.txt', 'java.lang.OutOfMemoryError', a2service: 'automate-elasticsearch.default')
 control 'gatherlogs.automate2.elasticsearch_out_of_memory' do
-  impact 1.0
+  impact 'high'
   title 'Check to see if Automate is reporting a OutOfMemoryError for ElasticSearch'
   desc "
 Automate is reporting OutOfMemoryError for ElasticSearch. Please check to heap size for ElasticSearch
@@ -74,7 +73,7 @@ end
 # max virtual memory areas vm.max_map_count [256000] is too low, increase to at     least [262144]
 es_vmc = log_analysis('journalctl_chef-automate.txt', 'max virtual memory areas vm.max_map_count \[\w+\] is too low, increase to at least \[\w+\]', a2service: 'automate-elasticsearch.default')
 control 'gatherlogs.automate2.elasticsearch_max_map_count_error' do
-  impact 1.0
+  impact 'high'
   title 'Check to see if Automate ES is reporting a error with vm.max_map_count setting'
   desc "
 ElasticSearch is reporting that the vm.max_map_count is not set correctly. This is a sysctl setting
@@ -97,7 +96,6 @@ end
 
 lb_workers = log_analysis('journalctl_chef-automate.txt', 'worker_connections are not enough', a2service: 'automate-load-balancer.default')
 control 'gatherlogs.automate2.loadbalancer_worker_connections' do
-  impact 1.0
   title 'Check to see if Automate is reporting a error with not enough workers for the load balancer'
   desc "
 This is an issue with older version of Automate 2 without persistant connections.
@@ -118,7 +116,6 @@ end
 
 butterfly_error = log_analysis('journalctl_chef-automate.txt', 'Butterfly error: Error reading or writing to DatFile', a2service: 'hab-sup')
 control 'gatherlogs.automate2.butterfly_dat_error' do
-  impact 1.0
   title 'Check to see if Automate is reporting an error reading or write to a DatFile'
   desc '
   The Habitat supervisor is having problems reading or writing to an internal DatFile.

--- a/profiles/automate2/inspec.yml
+++ b/profiles/automate2/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: InSpec profile for automate2 generated gather-logs
-version: 0.3.12
+version: 0.3.13
 
 depends:
   - name: common

--- a/profiles/chef-backend/controls/basic.rb
+++ b/profiles/chef-backend/controls/basic.rb
@@ -105,7 +105,6 @@ end
 # the clock difference against peer d4fed0cf06663880 is too high
 clocksync = log_analysis('var/log/chef-backend/etcd/current', 'the clock difference against peer .* is too high')
 control 'gatherlogs.chef-backend.clock_out_of_sync' do
-  impact 1.0
   title 'Check to see if ETCD is reporting issues with clocks being out of sync'
   desc "
 ETCD is reporting issues with the local system clocking being too far out of sync with other peers.

--- a/profiles/chef-backend/controls/issues.rb
+++ b/profiles/chef-backend/controls/issues.rb
@@ -19,7 +19,7 @@ end
 
 es_gc = log_analysis('var/log/chef-backend/elasticsearch/current', '\[o.e.m.j.JvmGcMonitorService\] .* \[gc\]')
 control 'gatherlogs.chef-backend.elasticsearch-high-gc-counts' do
-  impact 1.0
+  impact 'high'
   title 'Check to see if the ElasticSearch is reporting large number of GC events'
   desc "
 The ElasticSearch service is reporting a large number of GC events, this is usually

--- a/profiles/chef-backend/inspec.yml
+++ b/profiles/chef-backend/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: InSpec profile for Chef-Backend generated gather-logs
-version: 0.3.2
+version: 0.3.3
 
 depends:
   - name: common

--- a/profiles/chef-server/controls/erchef.rb
+++ b/profiles/chef-server/controls/erchef.rb
@@ -1,7 +1,6 @@
 # Checking presence of checksum: <<"aec79664a83e5086e738ab8659c81399">> for org <<"654cafca20690e27f34035e3e0a558ef">> from bucket "bookshelf" has taken longer than 5000 ms
 
 control 'gatherlogs.chef-server.erchef_bookshelf_errors' do
-  impact 1.0
   title 'Checking presence of checksum timeout for bookshelf'
   desc "
 opscode-erchef is reporting timeouts while trying to check for cookbook file checksums.
@@ -23,7 +22,6 @@ Please contact support to get this problem resolved"
 end
 
 control 'gatherlogs.chef-server.erchef-bad_actor-permission-errors' do
-  impact 1.0
   title 'Check erchef for permission errors related to bad_actor'
   desc "
   This usually indicates that a user has been disassociated from an organization
@@ -48,7 +46,7 @@ control 'gatherlogs.chef-server.erchef-bad_actor-permission-errors' do
 end
 
 control 'gatherlogs.chef-server.erchef-depsolver-startup-failure' do
-  impact 1.0
+  impact 'high'
   title 'Check for erchef startup errors for depsolver'
   desc "
   It appears that the erchef process is not starting due to an error when starting
@@ -73,7 +71,6 @@ end
 
 # moved to a separate check as it's not a good indication of the depsolver problem.
 control 'gatherlogs.chef-server.erchef-depsolver-listening' do
-  impact 1.0
   title 'Check for erchef process is listening on port 8000'
   desc "
   It appears that the erchef process is not listening on port 8000.  Please check
@@ -88,7 +85,6 @@ end
 
 error_limit = 100
 control 'gatherlogs.chef-server.erchef-500-errors' do
-  impact 1.0
   title 'Check for a large number of 500 errors being returned from erchef'
   desc "
   Found more than #{error_limit} number of messages with status=500 errors,

--- a/profiles/chef-server/controls/issues.rb
+++ b/profiles/chef-server/controls/issues.rb
@@ -26,7 +26,6 @@ control 'gatherlogs.chef-server.413-request-entity-too-large' do
 end
 
 control 'gatherlogs.chef-server.depsolver-timeouts' do
-  impact 1.0
   title 'Check for depsolver timeouts'
   desc '
   It appears that depsolver is being killed and causing a failure to
@@ -46,7 +45,6 @@ control 'gatherlogs.chef-server.depsolver-timeouts' do
 end
 
 control 'gatherlogs.chef-server.rabbitmq-connection-failure' do
-  impact 1.0
   title 'Check for erchef errors for rabbitmq connection errors'
   desc "
   It appears that the erchef process if having issues connecting to RabbitMQ.
@@ -65,7 +63,6 @@ control 'gatherlogs.chef-server.rabbitmq-connection-failure' do
 end
 
 control 'gatherlogs.chef-server.nginx-upstream-host-error' do
-  impact 1.0
   title 'Check nginx for errors related to upstream hosts'
   desc "
   NGINX is reporting issues finding the host for an upstream service.  This could

--- a/profiles/chef-server/inspec.yml
+++ b/profiles/chef-server/inspec.yml
@@ -5,7 +5,7 @@ copyright: Will Fisher
 copyright_email: will@chef.io
 license: Apache-2.0
 summary: InSpec profile for Chef-Server generated gather-logs
-version: 0.4.5
+version: 0.4.6
 
 depends:
   - name: common

--- a/spec/gatherlogs/cli_spec.rb
+++ b/spec/gatherlogs/cli_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Gatherlogs::CLI do
   end
 
   it 'should setup a new reporter' do
-    expect(Gatherlogs::Reporter).to receive(:new).with({:min_impact=>nil, :show_all_controls=>nil, :show_all_tests=>nil})
+    expect(Gatherlogs::Reporter).to receive(:new).with(min_impact: nil, show_all_controls: nil, show_all_tests: nil)
     cli.reporter
   end
 

--- a/spec/gatherlogs/cli_spec.rb
+++ b/spec/gatherlogs/cli_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Gatherlogs::CLI do
   end
 
   it 'should setup a new reporter' do
-    expect(Gatherlogs::Reporter).to receive(:new).with(show_all_controls: nil, show_all_tests: nil)
+    expect(Gatherlogs::Reporter).to receive(:new).with({:min_impact=>nil, :show_all_controls=>nil, :show_all_tests=>nil})
     cli.reporter
   end
 

--- a/spec/gatherlogs/control_report_spec.rb
+++ b/spec/gatherlogs/control_report_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Gatherlogs::ControlReport do
-  let(:reporter) do
-    Gatherlogs::ControlReport.new([{
+  let(:controls) do
+    [{
       'id' => '010.d.e.f',
       'tags' => {
         'summary' => 'Summary text',
@@ -31,7 +31,11 @@ RSpec.describe Gatherlogs::ControlReport do
         'status' => 'skipped',
         'code_desc' => 'Skipped because of reasons'
       }]
-    }], false, false)
+    }]
+  end
+
+  let(:reporter) do
+    Gatherlogs::ControlReport.new(controls)
   end
 
   before do
@@ -112,7 +116,7 @@ RSpec.describe Gatherlogs::ControlReport do
   end
 
   it 'should not return nil if show_all_tests is true' do
-    reporter.show_all_tests = true
+    reporter = Gatherlogs::ControlReport.new(controls, { show_all_tests: true })
     expect(reporter.format_result(success_result)).to_not be_nil
   end
 

--- a/spec/gatherlogs/control_report_spec.rb
+++ b/spec/gatherlogs/control_report_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Gatherlogs::ControlReport do
       }]
     }, {
       'id' => '000.a.b.c',
+      'impact' => '0.7',
       'tags' => { 'verbose' => true },
       'desc' => 'ABC Description text',
       'results' => [{
@@ -113,6 +114,16 @@ RSpec.describe Gatherlogs::ControlReport do
 
   it 'should return correct result message for failed' do
     expect(reporter.format_result_message(failed_result)).to eq "✗ CODE_DESC\n    Something failed"
+  end
+
+  it 'should not return any controls if min_impact is 1.0' do
+    reporter = Gatherlogs::ControlReport.new(controls, { min_impact: 1.0 })
+    expect(reporter.report).to be_empty
+  end
+
+  it 'should return one if min_impact is 0.7' do
+    reporter = Gatherlogs::ControlReport.new(controls, { min_impact: 0.7 })
+    expect(reporter.report).to_not be_empty
   end
 
   it 'should not return nil if show_all_tests is true' do

--- a/spec/gatherlogs/control_report_spec.rb
+++ b/spec/gatherlogs/control_report_spec.rb
@@ -117,17 +117,17 @@ RSpec.describe Gatherlogs::ControlReport do
   end
 
   it 'should not return any controls if min_impact is 1.0' do
-    reporter = Gatherlogs::ControlReport.new(controls, { min_impact: 1.0 })
+    reporter = Gatherlogs::ControlReport.new(controls, min_impact: 1.0)
     expect(reporter.report).to be_empty
   end
 
   it 'should return one if min_impact is 0.7' do
-    reporter = Gatherlogs::ControlReport.new(controls, { min_impact: 0.7 })
+    reporter = Gatherlogs::ControlReport.new(controls, min_impact: 0.7)
     expect(reporter.report).to_not be_empty
   end
 
   it 'should not return nil if show_all_tests is true' do
-    reporter = Gatherlogs::ControlReport.new(controls, { show_all_tests: true })
+    reporter = Gatherlogs::ControlReport.new(controls, show_all_tests: true)
     expect(reporter.format_result(success_result)).to_not be_nil
   end
 

--- a/spec/gatherlogs/reporter_spec.rb
+++ b/spec/gatherlogs/reporter_spec.rb
@@ -47,13 +47,13 @@ RSpec.describe Gatherlogs::Reporter do
 
   it 'should pass the show_all_controls to the control report' do
     reporter = Gatherlogs::Reporter.new(show_all_controls: true)
-    expect(Gatherlogs::ControlReport).to receive(:new).with([], { show_all_controls: true }) { double('results', system_info: {}, report: []) }
+    expect(Gatherlogs::ControlReport).to receive(:new).with([], show_all_controls: true) { double('results', system_info: {}, report: []) }
     expect(reporter.process_profile('controls' => [])).to eq(system_info: {}, report: [])
   end
 
   it 'should pass the show_all_tests to the control report' do
     reporter = Gatherlogs::Reporter.new(show_all_tests: true)
-    expect(Gatherlogs::ControlReport).to receive(:new).with([], { show_all_tests: true }) { double('results', system_info: {}, report: []) }
+    expect(Gatherlogs::ControlReport).to receive(:new).with([], show_all_tests: true) { double('results', system_info: {}, report: []) }
     expect(reporter.process_profile('controls' => [])).to eq(system_info: {}, report: [])
   end
 end

--- a/spec/gatherlogs/reporter_spec.rb
+++ b/spec/gatherlogs/reporter_spec.rb
@@ -41,19 +41,19 @@ RSpec.describe Gatherlogs::Reporter do
   end
 
   it 'should generate a blank report if there are no controls' do
-    expect(Gatherlogs::ControlReport).to receive(:new).with([], nil, nil) { double('results', system_info: {}, report: []) }
+    expect(Gatherlogs::ControlReport).to receive(:new).with([], {}) { double('results', system_info: {}, report: []) }
     expect(reporter.process_profile('controls' => [])).to eq(system_info: {}, report: [])
   end
 
   it 'should pass the show_all_controls to the control report' do
     reporter = Gatherlogs::Reporter.new(show_all_controls: true)
-    expect(Gatherlogs::ControlReport).to receive(:new).with([], true, nil) { double('results', system_info: {}, report: []) }
+    expect(Gatherlogs::ControlReport).to receive(:new).with([], { show_all_controls: true }) { double('results', system_info: {}, report: []) }
     expect(reporter.process_profile('controls' => [])).to eq(system_info: {}, report: [])
   end
 
   it 'should pass the show_all_tests to the control report' do
     reporter = Gatherlogs::Reporter.new(show_all_tests: true)
-    expect(Gatherlogs::ControlReport).to receive(:new).with([], nil, true) { double('results', system_info: {}, report: []) }
+    expect(Gatherlogs::ControlReport).to receive(:new).with([], { show_all_tests: true }) { double('results', system_info: {}, report: []) }
     expect(reporter.process_profile('controls' => [])).to eq(system_info: {}, report: [])
   end
 end


### PR DESCRIPTION
As a support engineer I would like to be able to have the gatherlogs reporter automatically reply to tickets when `critical` issues are found in the log bundle.

---

This adds a filter for results to only be shown when above given impact value.

To use this we will need to specify an `impact` value in the profile controls

From: https://www.inspec.io/docs/reference/dsl_inspec/
```
impact is a string, or numeric that measures the importance of the compliance results. 
Valid strings for impact are none, low, medium, high, and critical. 
The values are based off CVSS 3.0. A numeric value must be between 0.0 and 1.0. 

The value ranges are:
    0.0 to <0.01 these are controls with no impact, they only provide information
    0.01 to <0.4 these are controls with low impact
    0.4 to <0.7 these are controls with medium impact
    0.7 to <0.9 these are controls with high impact
    0.9 to 1.0 these are critical controls
```


For example:

```
control 'gatherlogs.automate2.elasticsearch_max_map_count_error' do
  impact 'high'
  title 'Check to see if Automate ES is reporting a error with vm.max_map_count setting'
  ...
end
```

Then to filter for the only impact `high` or above use `gatherlogs_report --impact 0.7`